### PR TITLE
fixed small typo in description (ancietns -> ancients)

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,8 +134,8 @@
                     <p>If you press on the number in the <em>change</em> field, the number changes to a long format and is automatically selected for copying. If you hold &quot;v&quot; when clicking on the corresponding ancient's purchase button, an input field will pop up. Paste the number you just copied into this field, and press &quot;Ok&quot;.</p>
                     
                     <h3>Why does the calculator tell me to level Morgulis more than I am able to?</h3>
-                    <p>It probably doesn't. If you have the outsider Chor'gorloth leveled, all ancietns become cheaper, including Chor'gorloth. This means that one level in Morgulis costs less than one soul when buying in bulk.</p>
-                    
+                    <p>It probably doesn't. If you have the outsider Chor'gorloth leveled, all ancients become cheaper, including Chor'gorloth. This means that one level in Morgulis costs less than one soul when buying in bulk.</p>
+
                     <h3>After buying the recommended ancients, why do I have more souls left over than the calculator predicts?</h3>
                     <p>Firstly, when you have many souls to spend the calculator will over-estimate the cost of a few ancients with a &quot;difficult&quot; cost formula. This approximation is accurate enough to yield very good recommendations; calculating it precisely often does not actually make a difference in regard to the number of levels recommended. Only the predicted cost becomes more accurate. Secondly, when you have only few souls to spend the predicted cost is accurate as far as the cost formulae go; there appear to be some issues in-game where an ancient sometimes costs one soul less or more than it should.</p>
                     


### PR DESCRIPTION
Noticed a small typo when looking at your site, decided fixing it was easier than making a new issue.
