### PR TITLE
Fix pasteable ancient level rounding

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -15,7 +15,7 @@ function numberToClickerHeroesPasteableString(number) {
         intPart = Math.round(number / Math.pow(10, b-10));
         return intPart + "0".repeat(b-10);
     } else {
-        return ""+number;
+        return ""+Math.round(number);
     }
 }
 


### PR DESCRIPTION
When selecting a field with the number of levels to add to an ancient,
the value will sometimes be rendered with a decimal point. Numbers like
1000.0000000015 or 999.9999999995. Unhappily, pasting this into the
ClickerHeroes game results in the numbers 10000000000015 and
9999999999995 being added, which is clearly not the idea.

This commit adds rounding to the presentation of these strings.