### PR TITLE
Fixing some collapse issues on input panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -735,6 +735,7 @@
             // collapse if small
             if($("#input-collapse-btn").is(":visible") && $("#input-collapse").is(":visible")){
                 $("#input-collapse").collapse('hide');
+                $("#config-collapse").collapse('hide');
             }
         });
 

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
                         <textarea id="savedata" style="width: 100%; height: 50px" onclick="this.select()"
                                   autofocus></textarea>
                         <div style="float: right; margin-top: 10px;">
-                            <button type="button" onclick="Import()" class="btn btn-primary" style="float: right;">
+                            <button type="button" onclick="Import()" class="btn btn-primary" id="importButton" style="float: right;">
                                 Import
                             </button>
                         </div>
@@ -682,6 +682,13 @@
             Import();
         });
 
+        $('#importButton').click(function(){
+            // collapse if small
+            if($("#input-collapse-btn").is(":visible") && $("#input-collapse").is(":visible")){
+                $("#input-collapse").collapse('hide');
+            }
+        });
+
         // Load game data
         $.ajax('data/ClickerHeroes_v8847.js', {
             complete: function (xhr) {
@@ -959,10 +966,7 @@
         data.useSoulsEnteredManually = false;
         calculateAndUpdate();
 
-        // collapse if small
-        if($("#input-collapse-btn").is(":visible") && $("#input-collapse").is(":visible")){
-            $("#input-collapse").collapse('hide');
-        }
+
     }
 
     function calculateAndUpdate() {


### PR DESCRIPTION
Noticed that because I had the logic for automatically collapsing the input panel within the import function that it was collapsing on any change to any control in the panel. This was causing issues with the hybrid slider and other input controls in the panel. Moved this functionality to the import button.

**Now the input panel will collapse automatically only when the import button itself is pressed on small devices.**

I added that functionality originally because I noted that even though the import function was running, there wasn't any indication that an action had been done. Collapsing the input after import tells the user that work was actually done.

*P.S. I like what you did with making the table collapse on small devices optional. Good thinking!*

**Thank you**